### PR TITLE
Add lootbox roulette with preference storage

### DIFF
--- a/public/css/global.css
+++ b/public/css/global.css
@@ -82,11 +82,15 @@ main {
 
   display: flex;
 
-  align-items: center;
+  align-items: flex-start;
 
   justify-content: center;
 
-  text-align: center;
+  padding: clamp(32px, 6vh, 72px) 20px 60px;
+
+  text-align: left;
+
+  overflow-y: auto;
 
 }
 
@@ -113,6 +117,8 @@ h1 {
   color: #fff;
 
   width: 300px;
+
+  margin: 0 auto;
 
 }
 
@@ -304,3 +310,309 @@ h1 {
 .admin-table td.delete-cell { white-space: nowrap; }
 
 
+
+/* Roulette layout */
+
+.roulette-page {
+  width: min(960px, 92vw);
+  background: rgba(0, 0, 0, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  padding: clamp(24px, 4vw, 48px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(24px, 3vw, 40px);
+}
+
+.roulette-header h1 {
+  margin: 0 0 12px 0;
+  font-size: clamp(2.2rem, 3vw, 3.2rem);
+}
+
+.preferences-summary {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 18px;
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 0.95rem;
+}
+
+.preferences-summary li {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 8px 14px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.preferences-summary strong {
+  color: #fff;
+  font-weight: 600;
+}
+
+.lootbox-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.lootbox-window {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  background: linear-gradient(135deg, rgba(20, 20, 30, 0.9), rgba(10, 10, 18, 0.9));
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.6);
+  min-height: 220px;
+}
+
+.lootbox-strip {
+  display: flex;
+  gap: 18px;
+  align-items: stretch;
+  padding: 32px 48px;
+  will-change: transform;
+}
+
+.lootbox-item {
+  flex: 0 0 180px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  padding: 16px 14px;
+  text-align: center;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+  border: 1px solid transparent;
+  transition: transform 0.3s ease, border-color 0.3s ease, background 0.3s ease;
+}
+
+.lootbox-item strong {
+  display: block;
+  font-size: 1.05rem;
+  margin-bottom: 6px;
+  color: #fff;
+}
+
+.lootbox-item span {
+  display: block;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lootbox-item.active {
+  background: rgba(40, 172, 226, 0.25);
+  border-color: rgba(40, 172, 226, 0.9);
+  transform: scale(1.06);
+}
+
+.lootbox-marker {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 4px;
+  transform: translateX(-50%);
+  background: linear-gradient(to bottom, rgba(40, 172, 226, 0), rgba(40, 172, 226, 0.85), rgba(40, 172, 226, 0));
+  pointer-events: none;
+}
+
+.spin-button {
+  padding: 14px 32px;
+  background: linear-gradient(135deg, #28ace2, #1d7fb0);
+  color: #fff;
+  font-weight: 600;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.spin-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.spin-button:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.45);
+}
+
+.lootbox-result {
+  width: 100%;
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 24px;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.4);
+}
+
+.lootbox-result h2 {
+  margin: 0 0 12px 0;
+  font-size: clamp(1.6rem, 2.4vw, 2.2rem);
+}
+
+.lootbox-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  margin-bottom: 12px;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.lootbox-meta span {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 6px 12px;
+}
+
+.lootbox-description {
+  font-size: 1rem;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.no-items-message {
+  text-align: center;
+  padding: 32px;
+  background: rgba(0, 0, 0, 0.45);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  width: 100%;
+}
+
+.no-items-message a {
+  color: #28ace2;
+  font-weight: 600;
+}
+
+/* Preferences page */
+
+.preferences-page {
+  width: min(880px, 94vw);
+  background: rgba(0, 0, 0, 0.65);
+  border-radius: 18px;
+  padding: clamp(24px, 5vw, 48px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
+}
+
+.preferences-page h1 {
+  margin-top: 0;
+  font-size: clamp(2rem, 2.6vw, 3rem);
+}
+
+.preferences-intro {
+  color: rgba(255, 255, 255, 0.85);
+  margin-bottom: 18px;
+  line-height: 1.5;
+}
+
+.preferences-form {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.preferences-form section {
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 14px;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.preferences-form h2 {
+  margin: 0 0 8px 0;
+}
+
+.preferences-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.pref-checkbox {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.pref-checkbox input {
+  width: 18px;
+  height: 18px;
+}
+
+.pref-checkbox span {
+  color: #fff;
+  font-weight: 500;
+}
+
+.slider-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.slider-scale {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.7);
+  margin-top: 8px;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.form-actions button {
+  padding: 12px 28px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #28ace2, #1d7fb0);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.4);
+}
+
+.preferences-flash {
+  border-radius: 12px;
+  padding: 12px 16px;
+  margin-bottom: 12px;
+  font-weight: 600;
+}
+
+.preferences-flash.success {
+  background: rgba(46, 204, 113, 0.25);
+  color: #9ef3c6;
+}
+
+.preferences-flash.error {
+  background: rgba(231, 76, 60, 0.25);
+  color: #f5b7b1;
+}
+
+@media (max-width: 640px) {
+  .lootbox-strip {
+    padding: 28px;
+  }
+
+  .lootbox-item {
+    flex-basis: 150px;
+  }
+}

--- a/public/header.php
+++ b/public/header.php
@@ -13,6 +13,7 @@
 <body>
 <header>
   <a class="btn" href="/index.php">Home</a>
+  <a class="btn" href="/preferences.php">Preferences</a>
   <?php if (!empty($_SESSION['uid'])): ?>
     <?php if (!empty($_SESSION['is_admin'])): ?>
       <a class="btn" href="/admin/admin.php">Admin</a>

--- a/public/index.php
+++ b/public/index.php
@@ -2,12 +2,238 @@
 
 session_start();
 
+require __DIR__ . '/../src/db.php';
+require __DIR__ . '/../src/preferences.php';
+
+$userId = isset($_SESSION['uid']) ? (int)$_SESSION['uid'] : null;
+$courses = fetch_course_options($pdo);
+$proteins = fetch_protein_options($pdo);
+$preferences = load_preferences($pdo, $userId, $courses, $proteins);
+
+$courseLabels = [];
+foreach ($courses as $course) {
+    $courseLabels[$course['slug']] = $course['label'];
+}
+$proteinLabels = [];
+foreach ($proteins as $protein) {
+    $proteinLabels[$protein['slug']] = $protein['label'];
+}
+
+$itemsStmt = $pdo->query('SELECT i.id, i.name, i.description, i.image_path, i.base_spice, c.slug AS course_slug, c.label AS course_label
+    FROM items i
+    INNER JOIN courses c ON c.id = i.course_id
+    WHERE i.enabled = 1
+    ORDER BY i.name');
+$items = $itemsStmt->fetchAll();
+
+$proteinRows = $pdo->query('SELECT iap.item_id, p.slug, p.label FROM item_allowed_proteins iap INNER JOIN proteins p ON p.id = iap.protein_id')->fetchAll();
+$proteinMap = [];
+foreach ($proteinRows as $row) {
+    $proteinMap[(int)$row['item_id']][] = [
+        'slug'  => $row['slug'],
+        'label' => $row['label'],
+    ];
+}
+
+$filteredItems = [];
+foreach ($items as $item) {
+    $itemId = (int)$item['id'];
+    $itemProteins = $proteinMap[$itemId] ?? [];
+    $itemProteinSlugs = array_column($itemProteins, 'slug');
+
+    if (!in_array($item['course_slug'], $preferences['courses'], true)) {
+        continue;
+    }
+
+    if (!empty($preferences['proteins'])) {
+        if (empty($itemProteinSlugs)) {
+            continue;
+        }
+        if (!array_intersect($itemProteinSlugs, $preferences['proteins'])) {
+            continue;
+        }
+    }
+
+    if ((int)$item['base_spice'] > (int)$preferences['max_spice']) {
+        continue;
+    }
+
+    $item['proteins'] = $itemProteins;
+    $filteredItems[] = $item;
+}
+
+$clientItems = [];
+foreach ($filteredItems as $item) {
+    $clientItems[] = [
+        'name'        => $item['name'],
+        'description' => $item['description'] ?? '',
+        'courseLabel' => $item['course_label'],
+        'courseSlug'  => $item['course_slug'],
+        'proteins'    => $item['proteins'],
+        'baseSpice'   => (int)$item['base_spice'],
+        'imagePath'   => $item['image_path'] ?? null,
+    ];
+}
+
+$itemsJson = json_encode($clientItems, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+if ($itemsJson === false) {
+    $itemsJson = '[]';
+}
+
+$selectedCourseLabels = array_map(fn ($slug) => $courseLabels[$slug] ?? $slug, $preferences['courses']);
+$selectedProteinLabels = array_map(fn ($slug) => $proteinLabels[$slug] ?? $slug, $preferences['proteins']);
+
 include __DIR__ . '/header.php';
-
 ?>
+  <div class="roulette-page">
+    <div class="roulette-header">
+      <h1>Spin the Senn Roulette</h1>
+      <p>Press the button and let fate pick tonight&apos;s dish.</p>
+      <ul class="preferences-summary">
+        <li><strong>Courses</strong> <?= htmlspecialchars(implode(', ', $selectedCourseLabels)) ?></li>
+        <li><strong>Proteins</strong> <?= htmlspecialchars(implode(', ', $selectedProteinLabels)) ?></li>
+        <li><strong>Max spice</strong> <?= (int)$preferences['max_spice'] ?> / 5</li>
+      </ul>
+    </div>
 
-  <h1>yo</h1>
+    <?php if (empty($filteredItems)): ?>
+      <div class="no-items-message">
+        <p>No dishes match your current filters. Try <a href="/preferences.php">adjusting your preferences</a> to widen the pool.</p>
+      </div>
+    <?php else: ?>
+      <div class="lootbox-wrapper">
+        <div class="lootbox-window" id="lootbox-window">
+          <div class="lootbox-strip" id="lootbox-strip">
+            <?php for ($loop = 0; $loop < 3; $loop++): ?>
+              <?php foreach ($filteredItems as $index => $item): ?>
+                <div class="lootbox-item" data-loop="<?= $loop ?>" data-index="<?= $index ?>">
+                  <strong><?= htmlspecialchars($item['name']) ?></strong>
+                  <span><?= htmlspecialchars($item['course_label']) ?></span>
+                </div>
+              <?php endforeach; ?>
+            <?php endfor; ?>
+          </div>
+          <div class="lootbox-marker"></div>
+        </div>
+        <button class="spin-button" id="spin-button">Spin the wheel</button>
+      </div>
 
+      <div class="lootbox-result" id="lootbox-result">
+        <h2 id="lootbox-result-title">Ready when you are</h2>
+        <div class="lootbox-meta" id="lootbox-result-meta"></div>
+        <p class="lootbox-description" id="lootbox-result-description">Hit the button to let the carousel choose a dish.</p>
+      </div>
+    <?php endif; ?>
+  </div>
+
+  <script>
+    const lootboxItems = <?= $itemsJson ?>;
+
+    function formatProteins(proteins) {
+      if (!Array.isArray(proteins) || proteins.length === 0) {
+        return 'Flexible protein';
+      }
+      return proteins.map((p) => p.label).join(', ');
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const spinButton = document.getElementById('spin-button');
+      const strip = document.getElementById('lootbox-strip');
+      const windowEl = document.getElementById('lootbox-window');
+      const resultTitle = document.getElementById('lootbox-result-title');
+      const resultMeta = document.getElementById('lootbox-result-meta');
+      const resultDescription = document.getElementById('lootbox-result-description');
+
+      if (!spinButton || !strip || !windowEl || lootboxItems.length === 0) {
+        if (spinButton) {
+          spinButton.disabled = true;
+        }
+        return;
+      }
+
+      let activeCard = null;
+
+      const centerCard = (loopIndex, itemIndex, animate = false, duration = 2200) => {
+        const selector = `.lootbox-item[data-loop="${loopIndex}"][data-index="${itemIndex}"]`;
+        const card = strip.querySelector(selector);
+        if (!card) {
+          return null;
+        }
+        const offset = card.offsetLeft + card.offsetWidth / 2 - windowEl.offsetWidth / 2;
+        if (!animate) {
+          strip.style.transition = 'none';
+        } else {
+          strip.style.transition = `transform ${duration}ms cubic-bezier(0.2, 0.8, 0.1, 1)`;
+        }
+        strip.style.transform = `translateX(${-offset}px)`;
+        return card;
+      };
+
+      const updateResult = (item) => {
+        if (!item) {
+          return;
+        }
+        if (resultTitle) {
+          resultTitle.textContent = item.name;
+        }
+        if (resultDescription) {
+          resultDescription.textContent = item.description || 'No description available yet.';
+        }
+        if (resultMeta) {
+          resultMeta.innerHTML = '';
+          const metaBits = [
+            `${item.courseLabel}`,
+            `Spice: ${item.baseSpice}/5`,
+            `Proteins: ${formatProteins(item.proteins)}`
+          ];
+          metaBits.forEach((text) => {
+            const badge = document.createElement('span');
+            badge.textContent = text;
+            resultMeta.appendChild(badge);
+          });
+        }
+      };
+
+      // Prime the strip so the first item is centred.
+      const initialCard = centerCard(1, 0, false, 0);
+      activeCard = initialCard;
+      if (initialCard) {
+        initialCard.classList.add('active');
+        updateResult(lootboxItems[0]);
+      }
+
+      spinButton.addEventListener('click', () => {
+        if (spinButton.disabled) {
+          return;
+        }
+        spinButton.disabled = true;
+
+        const targetIndex = Math.floor(Math.random() * lootboxItems.length);
+        const loopTarget = lootboxItems.length > 1 ? 2 : 1;
+        const duration = 2100 + Math.floor(Math.random() * 500);
+
+        // Reset to the first loop for a consistent start.
+        strip.style.transition = 'none';
+        centerCard(0, targetIndex, false, 0);
+        // Force repaint so the transition kicks in on the next frame.
+        void strip.offsetWidth;
+
+        const landingCard = centerCard(loopTarget, targetIndex, true, duration);
+        if (!landingCard) {
+          spinButton.disabled = false;
+          return;
+        }
+
+        setTimeout(() => {
+          if (activeCard) {
+            activeCard.classList.remove('active');
+          }
+          landingCard.classList.add('active');
+          activeCard = landingCard;
+          updateResult(lootboxItems[targetIndex]);
+          spinButton.disabled = false;
+        }, duration + 120);
+      });
+    });
+  </script>
 <?php include __DIR__ . '/footer.php'; ?>
-
-

--- a/public/preferences.php
+++ b/public/preferences.php
@@ -1,0 +1,100 @@
+<?php
+
+session_start();
+
+require __DIR__ . '/../src/db.php';
+require __DIR__ . '/../src/preferences.php';
+
+$userId = isset($_SESSION['uid']) ? (int)$_SESSION['uid'] : null;
+$courses = fetch_course_options($pdo);
+$proteins = fetch_protein_options($pdo);
+$current = load_preferences($pdo, $userId, $courses, $proteins);
+$saved = false;
+$error = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $prefs = [
+        'courses'   => array_map('strval', $_POST['courses'] ?? []),
+        'proteins'  => array_map('strval', $_POST['proteins'] ?? []),
+        'max_spice' => $_POST['max_spice'] ?? $current['max_spice'],
+    ];
+
+    try {
+        persist_preferences($pdo, $userId, $prefs, $courses, $proteins);
+        $saved = true;
+        $current = load_preferences($pdo, $userId, $courses, $proteins);
+    } catch (Throwable $e) {
+        $error = 'Unable to save your preferences right now. Please try again.';
+    }
+}
+
+include __DIR__ . '/header.php';
+?>
+  <div class="preferences-page">
+    <h1>Dish Preferences</h1>
+
+    <p class="preferences-intro">
+      Tailor the dishes that appear in the roulette. <?php if ($userId !== null): ?>Your choices are saved to your account.<?php else: ?>We save your selections in a cookie so they stick on this device.<?php endif; ?>
+    </p>
+
+    <?php if (!empty($saved)): ?>
+      <div class="preferences-flash success">Preferences saved!</div>
+    <?php endif; ?>
+    <?php if (!empty($error)): ?>
+      <div class="preferences-flash error"><?= htmlspecialchars($error) ?></div>
+    <?php endif; ?>
+
+    <form method="post" class="preferences-form">
+      <section>
+        <h2>Courses</h2>
+        <p>Select the types of dishes you want to see.</p>
+        <div class="preferences-grid">
+          <?php foreach ($courses as $course): ?>
+            <?php $checked = in_array($course['slug'], $current['courses'], true); ?>
+            <label class="pref-checkbox">
+              <input type="checkbox" name="courses[]" value="<?= htmlspecialchars($course['slug']) ?>" <?= $checked ? 'checked' : '' ?>>
+              <span><?= htmlspecialchars($course['label']) ?></span>
+            </label>
+          <?php endforeach; ?>
+        </div>
+      </section>
+
+      <section>
+        <h2>Proteins</h2>
+        <p>We only show dishes that can be prepared with your selected proteins.</p>
+        <div class="preferences-grid">
+          <?php foreach ($proteins as $protein): ?>
+            <?php $checked = in_array($protein['slug'], $current['proteins'], true); ?>
+            <label class="pref-checkbox">
+              <input type="checkbox" name="proteins[]" value="<?= htmlspecialchars($protein['slug']) ?>" <?= $checked ? 'checked' : '' ?>>
+              <span><?= htmlspecialchars($protein['label']) ?></span>
+            </label>
+          <?php endforeach; ?>
+        </div>
+      </section>
+
+      <section>
+        <h2>Heat tolerance</h2>
+        <label class="slider-label" for="max_spice">Maximum spice level: <strong><span id="spice-output"><?= (int)$current['max_spice'] ?></span></strong></label>
+        <input id="max_spice" name="max_spice" type="range" min="0" max="5" step="1" value="<?= (int)$current['max_spice'] ?>">
+        <div class="slider-scale">
+          <span>0</span><span>1</span><span>2</span><span>3</span><span>4</span><span>5</span>
+        </div>
+      </section>
+
+      <div class="form-actions">
+        <button type="submit">Save preferences</button>
+      </div>
+    </form>
+  </div>
+
+  <script>
+    const spiceInput = document.getElementById('max_spice');
+    const spiceOutput = document.getElementById('spice-output');
+    if (spiceInput && spiceOutput) {
+      spiceInput.addEventListener('input', () => {
+        spiceOutput.textContent = spiceInput.value;
+      });
+    }
+  </script>
+<?php include __DIR__ . '/footer.php'; ?>

--- a/src/db.php
+++ b/src/db.php
@@ -38,6 +38,14 @@ $pdo->exec('PRAGMA foreign_keys = ON');
 
 function migrate(PDO $pdo): void {
 
+    $pdo->exec('CREATE TABLE IF NOT EXISTS users (
+        id         INTEGER PRIMARY KEY AUTOINCREMENT,
+        username   TEXT NOT NULL UNIQUE,
+        password   TEXT NOT NULL,
+        is_admin   INTEGER NOT NULL DEFAULT 0 CHECK (is_admin IN (0,1)),
+        created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    )');
+
     // Courses (mains/appetisers)
 
     $pdo->exec('CREATE TABLE IF NOT EXISTS courses (
@@ -112,6 +120,15 @@ function migrate(PDO $pdo): void {
 
         FOREIGN KEY (protein_id) REFERENCES proteins(id) ON DELETE RESTRICT
 
+    )');
+
+
+
+    $pdo->exec('CREATE TABLE IF NOT EXISTS user_preferences (
+        user_id      INTEGER PRIMARY KEY,
+        filters_json TEXT NOT NULL,
+        updated_at   TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     )');
 
 

--- a/src/preferences.php
+++ b/src/preferences.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+const PREF_COOKIE_NAME = 'sennroulette_preferences';
+const PREF_COOKIE_TTL = 31536000; // 1 year
+
+/**
+ * Fetch course options from DB.
+ *
+ * @return array<int, array{ id:int, slug:string, label:string }>
+ */
+function fetch_course_options(PDO $pdo): array
+{
+    $stmt = $pdo->query('SELECT id, slug, label FROM courses ORDER BY label');
+    return $stmt->fetchAll();
+}
+
+/**
+ * Fetch protein options from DB.
+ *
+ * @return array<int, array{ id:int, slug:string, label:string }>
+ */
+function fetch_protein_options(PDO $pdo): array
+{
+    $stmt = $pdo->query('SELECT id, slug, label FROM proteins ORDER BY label');
+    return $stmt->fetchAll();
+}
+
+/**
+ * Build the default preferences (all options selected).
+ */
+function default_preferences(array $courses, array $proteins): array
+{
+    return [
+        'courses'   => array_values(array_column($courses, 'slug')),
+        'proteins'  => array_values(array_column($proteins, 'slug')),
+        'max_spice' => 5,
+    ];
+}
+
+/**
+ * Ensure the provided preferences contain only known values.
+ */
+function sanitise_preferences(array $prefs, array $courses, array $proteins): array
+{
+    $courseSlugs  = array_column($courses, 'slug');
+    $proteinSlugs = array_column($proteins, 'slug');
+
+    $sanitisedCourses = array_values(array_intersect($prefs['courses'] ?? [], $courseSlugs));
+    $sanitisedProteins = array_values(array_intersect($prefs['proteins'] ?? [], $proteinSlugs));
+
+    $maxSpice = $prefs['max_spice'] ?? 5;
+    if (!is_numeric($maxSpice)) {
+        $maxSpice = 5;
+    }
+    $maxSpice = max(0, min(5, (int)$maxSpice));
+
+    if (empty($sanitisedCourses)) {
+        $sanitisedCourses = $courseSlugs;
+    }
+    if (empty($sanitisedProteins)) {
+        $sanitisedProteins = $proteinSlugs;
+    }
+
+    return [
+        'courses'   => $sanitisedCourses,
+        'proteins'  => $sanitisedProteins,
+        'max_spice' => $maxSpice,
+    ];
+}
+
+/**
+ * Load preferences from DB or cookie.
+ */
+function load_preferences(PDO $pdo, ?int $userId, array $courses, array $proteins): array
+{
+    $defaults = default_preferences($courses, $proteins);
+
+    if ($userId !== null) {
+        $stmt = $pdo->prepare('SELECT filters_json FROM user_preferences WHERE user_id = ?');
+        $stmt->execute([$userId]);
+        $row = $stmt->fetch();
+        if ($row && is_string($row['filters_json'])) {
+            try {
+                $data = json_decode($row['filters_json'], true, 512, JSON_THROW_ON_ERROR);
+            } catch (Throwable $e) {
+                $data = null;
+            }
+            if (is_array($data)) {
+                return sanitise_preferences($data, $courses, $proteins);
+            }
+        }
+    }
+
+    if (!empty($_COOKIE[PREF_COOKIE_NAME])) {
+        try {
+            $data = json_decode((string)$_COOKIE[PREF_COOKIE_NAME], true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable $e) {
+            $data = null;
+        }
+        if (is_array($data)) {
+            return sanitise_preferences($data, $courses, $proteins);
+        }
+    }
+
+    return $defaults;
+}
+
+/**
+ * Persist preferences either to DB (signed-in users) or to a cookie.
+ */
+function persist_preferences(PDO $pdo, ?int $userId, array $prefs, array $courses, array $proteins): void
+{
+    $prefs = sanitise_preferences($prefs, $courses, $proteins);
+    $json = json_encode($prefs, JSON_THROW_ON_ERROR);
+
+    if ($userId !== null) {
+        $stmt = $pdo->prepare('REPLACE INTO user_preferences (user_id, filters_json, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)');
+        $stmt->execute([$userId, $json]);
+    } else {
+        setcookie(PREF_COOKIE_NAME, $json, [
+            'expires'  => time() + PREF_COOKIE_TTL,
+            'path'     => '/',
+            'secure'   => false,
+            'httponly' => false,
+            'samesite' => 'Lax',
+        ]);
+        $_COOKIE[PREF_COOKIE_NAME] = $json;
+    }
+}
+
+?>


### PR DESCRIPTION
## Summary
- replace the landing page with a horizontal lootbox spinner that filters dishes using saved preferences
- add a dedicated preferences screen that persists selections to cookies for guests or the database for signed-in users
- extend database migrations and shared styles to support the roulette UI and preference management

## Testing
- php -l public/index.php
- php -l public/preferences.php
- php -l src/preferences.php
- php -l src/db.php

------
https://chatgpt.com/codex/tasks/task_e_68e5ec326208832aa7b56535e8f9bf1a